### PR TITLE
Add support for HTTP/2

### DIFF
--- a/includes/module_http.php
+++ b/includes/module_http.php
@@ -350,8 +350,8 @@ class knHttp{
 		$head = array();
 		if(is_array($headers) && count($headers)>0)
 		foreach($headers as $line){
-			if(preg_match('~^http/\d+.\d+\s(\d+)\s~iUs',$line,$matches)){
-				$head['HTTP_RESPONSE'] = (int)$matches[1];
+			if(preg_match('~^http/\d+(\.\d){0,1}\s(\d+)\s~iUs',$line,$matches)){
+				$head['HTTP_RESPONSE'] = (int)$matches[2];
 				continue;
 			}else{
 				$pair = preg_split('~:~',$line,2);


### PR DESCRIPTION
Change the logic to parse the HTTP/2 response header.

Old parser fails to recognize http versions of `http/#` instead requiring `http/#.#`, we now make it possible to recognize `http/2` as a valid http response preamble.

Possibly alternate solution to #17  instead of forcing `http/1.1`. Though it also seems reasonable to force `1.1` as we can't really take advantage of `http/2`. Perhaps build in as an option.